### PR TITLE
remove authentication from the metrics endpoint

### DIFF
--- a/base/vault-namespace/kustomization.yaml
+++ b/base/vault-namespace/kustomization.yaml
@@ -4,3 +4,7 @@ resources:
   - rbac.yaml
   - vault.yaml
   - vault-pki.yaml
+configMapGenerator:
+  - name: nginx-config
+    files:
+      - resources/nginx.conf

--- a/base/vault-namespace/resources/nginx.conf
+++ b/base/vault-namespace/resources/nginx.conf
@@ -1,0 +1,9 @@
+server {
+    listen       8080;
+    server_name  localhost;
+
+    location /__/metrics {
+        proxy_pass https://127.0.0.1:8200/v1/sys/metrics?format=prometheus;
+        proxy_ssl_verify off;
+    }
+}

--- a/base/vault-namespace/vault.yaml
+++ b/base/vault-namespace/vault.yaml
@@ -115,6 +115,9 @@ spec:
                   cluster_address = "0.0.0.0:8201"
                   tls_key_file    = "/etc/tls/tls.key"
                   tls_cert_file   = "/etc/tls/tls.crt"
+                  telemetry {
+                    unauthenticated_metrics_access = true
+                  }
                 }
 
                 storage "raft" {
@@ -133,37 +136,6 @@ spec:
           volumeMounts:
             - name: vault-config
               mountPath: /vault/config
-        # Write nginx config to file
-        - name: nginx-config
-          image: alpine
-          command:
-            - sh
-            - -c
-            - |
-              VAULT_TOKEN="${VAULT_TOKEN:-"000000000000000"}";
-              echo "${NGINX_CONFIG}" | sed 's/%VAULT_TOKEN%/'"${VAULT_TOKEN}"'/g' > /etc/nginx/conf.d/default.conf;
-          env:
-            - name: VAULT_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: vault
-                  key: root-token
-                  optional: true
-            - name: NGINX_CONFIG
-              value: |
-                server {
-                    listen       8080;
-                    server_name  localhost;
-
-                    location /__/metrics {
-                        proxy_pass https://127.0.0.1:8200/v1/sys/metrics?format=prometheus;
-                        proxy_set_header X-Vault-Token %VAULT_TOKEN%;
-                        proxy_ssl_verify off;
-                    }
-                }
-          volumeMounts:
-            - name: nginx-config
-              mountPath: /etc/nginx/conf.d
       containers:
         - name: initializer
           image: alpine
@@ -233,9 +205,6 @@ spec:
               for i in $(seq $(($replicas - 1))) ; do
                 join_replica $i;
               done
-
-              # Restart pods to enable metrics
-              kubectl delete pod -l app="${vault_name}"
           env:
             - name: VAULT_CACERT
               value: "/etc/tls/ca.crt"
@@ -293,7 +262,7 @@ spec:
             - name: tls
               mountPath: /etc/tls
         - name: vault
-          image: vault:1.2.3
+          image: vault:1.3.2
           livenessProbe:
             # Alive if Vault is uninitialized or unsealed and active/standby
             httpGet:
@@ -369,7 +338,8 @@ spec:
         - name: vault-config
           emptyDir: {}
         - name: nginx-config
-          emptyDir: {}
+          configMap:
+            name: nginx-config
         - name: ssl-certs
           emptyDir: {}
   volumeClaimTemplates:


### PR DESCRIPTION
The latest versions of vault include a feature that allows you to disable authentication on the metrics endpoint. This means we don't need to inject the vault token into the nginx config or
restart the pods at the end of the initializer to pick up the newly created token.