### PR TITLE
match vault process exactly in reloader

### DIFF
--- a/base/vault-namespace/vault.yaml
+++ b/base/vault-namespace/vault.yaml
@@ -224,7 +224,7 @@ spec:
               echo '#!/bin/sh
               if [ "$#" -eq 3 ] && [ "$3" == "..data" ]; then
                   echo "[" $(date -uIseconds) "] config seems to have changed, reloading ..."
-                  vault_pid=$(pgrep vault)
+                  vault_pid=$(pgrep -x vault)
                   kill -HUP "${vault_pid}"
               fi' > /reload && chmod +x /reload && inotifyd /reload /etc/tls:y
           volumeMounts:


### PR DESCRIPTION
The vault-toolkit scripts are prefixed with `vault-` so they were being matched by`pgrep vault` in the reloader and returning multiple pids which caused the cert reload to fail. Using the `-x` flag does an exact match for the name `vault`.