### PR TITLE
remove the ssl-certs dir volume

### DIFF
--- a/base/vault-namespace/vault.yaml
+++ b/base/vault-namespace/vault.yaml
@@ -75,23 +75,6 @@ spec:
                 topologyKey: failure-domain.beta.kubernetes.io/zone
               weight: 100
       initContainers:
-        # Install ca cert as a root CA
-        - name: ca
-          image: alpine
-          command:
-            - sh
-            - -c
-            - |
-              set -e
-              apk add --update ca-certificates
-              cp /etc/tls/ca.crt /usr/local/share/ca-certificates/vault-ca.crt
-              update-ca-certificates
-              cp /etc/ssl/certs/* /ssl-certs
-          volumeMounts:
-            - name: tls
-              mountPath: /etc/tls
-            - name: ssl-certs
-              mountPath: /ssl-certs
         # Write vault config to file
         - name: vault-config
           image: alpine
@@ -197,8 +180,6 @@ spec:
               mountPath: /vault/storage
             - name: tls
               mountPath: /etc/tls
-            - name: ssl-certs
-              mountPath: /etc/ssl/certs
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -242,8 +223,6 @@ spec:
         - name: nginx-config
           configMap:
             name: nginx-config
-        - name: ssl-certs
-          emptyDir: {}
   volumeClaimTemplates:
     - metadata:
         name: storage

--- a/vault-toolkit/vault-initializer.sh
+++ b/vault-toolkit/vault-initializer.sh
@@ -51,7 +51,12 @@ join_replica()
     sleep 3;
   done;
 
-  curl -s --cacert "${VAULT_CACERT}" "${replica_addr}/v1/sys/storage/raft/join" -XPUT -d '{"leader_api_addr":"'"${leader_addr}"'"}'
+  leader_ca_cert=$(awk 'NF {printf "%s\\n",$0;}' "${VAULT_CACERT}")
+  curl -s --cacert "${VAULT_CACERT}" "${replica_addr}/v1/sys/storage/raft/join" -XPUT \
+    -d '{
+      "leader_api_addr":"'"${leader_addr}"'",
+      "leader_ca_cert":"'"${leader_ca_cert}"'"
+    }'
   curl -s --cacert "${VAULT_CACERT}" "${replica_addr}/v1/sys/unseal" -XPUT -d '{"key":"'"${unseal_key}"'"}'
   echo "${replica_name} joined and initialized"
 }


### PR DESCRIPTION
We were adding the vault ca cert to the root ca bundle for two reasons:
- To workaround this issue with raft join: hashicorp/vault#7269
- To make things simpler when manually bootstrapping vault by removing the need to specify the path to the ca cert on the command line

Now that we're automatically bootstrapping the cluster and the issue is fixed, we can get rid of it.