### PR TITLE
run initializer on all replicas

### DIFF
--- a/vault-toolkit/vault-initializer.sh
+++ b/vault-toolkit/vault-initializer.sh
@@ -1,65 +1,62 @@
 #!/bin/sh
 
-# This script runs on the first replica in the cluster, initializing each replica and joining
-# them together into a raft cluster.
+# This script initializes the local vault.
 
-# Only run the initializer in the first replica
-replica="${HOSTNAME: -1}";
-if [ "${replica}" != "0" ];then
-  echo "this replica is not responsible for initialization, going to sleep";
-  while true; do sleep 86400; done
-fi
+set -e
 
 # Validations and defaults
-: ${VAULT_CACERT:?"Need to set VAULT_CACERT"};
-vault_name="${VAULT_ADDR:-"vault"}";
-leader_addr="https://${vault_name}-0.${vault_name}-cluster:8200";
-replicas="${VAULT_REPLICAS:-"3"}";
+: ${VAULT_CACERT:?"Need to set VAULT_CACERT"}
+local_addr="${VAULT_LOCAL_ADDR:-"https://127.0.0.1:8200"}"
+vault_addr="${VAULT_ADDR:-"https://vault:8200"}"
 
 # Wait until vault answers the initialization check
+initialized=$(curl -s --cacert "${VAULT_CACERT}" "${local_addr}/v1/sys/init" | jq '.initialized')
 until [ "${initialized}" = "true" -o "${initialized}" = "false" ]; do
-  initialized=$(curl -s --cacert "${VAULT_CACERT}" "${leader_addr}/v1/sys/init" | jq '.initialized');
-  echo 'leader not ready, sleeping for 3 seconds';
-  sleep 3;
-done;
+  initialized=$(curl -s --cacert "${VAULT_CACERT}" "${local_addr}/v1/sys/init" | jq '.initialized')
+  echo "vault not ready, sleeping for 3 seconds"
+  sleep 3
+done
 
-if [ "${initialized}" = "true" ];then
-  echo "vault is already initialized, going to sleep";
+if [ "${initialized}" = "true" ]; then
+  echo "vault is already initialized, going to sleep"
   while true; do sleep 86400; done
 fi
 
-# Initialize vault and update secret
-init=$(curl -s --cacert "${VAULT_CACERT}" "${leader_addr}/v1/sys/init" \
-  -XPUT -d '{"secret_shares":1,"secret_threshold": 1}');
-token=$(echo "${init}" | jq -r '.root_token');
-unseal_key=$(echo "${init}" | jq -r '.keys[0]');
-kubectl patch secret vault -p '{"stringData":{"unseal-key":"'"${unseal_key}"'","root-token":"'"${token}"'"}}'
-echo "vault initialized"
-
-# Unseal leader
-curl -s --cacert "${VAULT_CACERT}" "${leader_addr}/v1/sys/unseal" -XPUT -d '{"key":"'"${unseal_key}"'"}'
-echo "leader unsealed"
-
-# Wait for replicas api and join and unseal them
-join_replica()
-{
-  replica_number="$1";
-  replica_name="${vault_name}-${replica_number}";
-  replica_addr="https://${replica_name}.${vault_name}-cluster:8200";
-  until curl -s --cacert "${VAULT_CACERT}" "${replica_addr}/v1/sys/init"; do
-    echo "${replica_name} not ready, sleeping for 3 seconds";
-    sleep 3;
-  done;
-
+# If there's no current leader and this is the first replica then initialize
+# the cluster, otherwise join the current leader
+leader_addr=$(curl -s --cacert "${VAULT_CACERT}" "${vault_addr}/v1/sys/leader" | jq -r '.leader_address')
+if [ -z "${leader_addr}" ]; then
+  if [ "${HOSTNAME: -1}" = "0" ]; then
+    # Initialize vault and update secret
+    init=$(curl -s --cacert "${VAULT_CACERT}" "${local_addr}/v1/sys/init" \
+      -XPUT -d '{"secret_shares":1,"secret_threshold": 1}')
+    token=$(echo "${init}" | jq -r '.root_token')
+    unseal_key=$(echo "${init}" | jq -r '.keys[0]')
+    kubectl patch secret vault -p '{"stringData":{"unseal-key":"'"${unseal_key}"'","root-token":"'"${token}"'"}}'
+    echo "vault initialized"
+  else 
+    echo "Can't find a leader to join"
+    exit 1
+  fi
+else
+  # join the leader
   leader_ca_cert=$(awk 'NF {printf "%s\\n",$0;}' "${VAULT_CACERT}")
-  curl -s --cacert "${VAULT_CACERT}" "${replica_addr}/v1/sys/storage/raft/join" -XPUT \
+  curl -s --cacert "${VAULT_CACERT}" "${local_addr}/v1/sys/storage/raft/join" -XPUT \
     -d '{
       "leader_api_addr":"'"${leader_addr}"'",
-      "leader_ca_cert":"'"${leader_ca_cert}"'"
+      "leader_ca_cert":"'"${leader_ca_cert}"'",
+      "retry":true
     }'
-  curl -s --cacert "${VAULT_CACERT}" "${replica_addr}/v1/sys/unseal" -XPUT -d '{"key":"'"${unseal_key}"'"}'
-  echo "${replica_name} joined and initialized"
-}
-for i in $(seq $(($replicas - 1))) ; do
-  join_replica $i;
-done
+  echo "joined leader: ${leader_addr}"
+fi
+
+# Unseal vault
+echo "unsealing vault"
+if [ -z "${unseal_key}" ]; then
+  unseal_key=$(kubectl get secret vault -o jsonpath={.data.unseal-key} | base64 -d)
+fi
+curl -s --cacert "${VAULT_CACERT}" "${local_addr}/v1/sys/unseal" -XPUT -d '{"key":"'"${unseal_key}"'"}'
+echo "vault unsealed"
+
+echo "initialization completed, going to sleep"
+while true; do sleep 86400; done


### PR DESCRIPTION
This modifies the model of our bootstrapping so that the initializer runs on each replica and
configures only the replica which it runs on.

I think this has a number of benefits:
* Supports scaling replicas. If you increase the number of replicas, a new replica will join
itself to the current leader automatically.
* Removes the need to provide the number of replicas to the initializer.
* If a replica in the statefulset becomes unrecoverable or reverts to an uninitialized
state - perhaps due to losing its pvc - it will be returned to the cluster on startup.
* When initialization fails, for whatever reason, initialization can be reattempted by
restarting the affected pod.