### PR TITLE
rotate static AWS IAM credentials

### DIFF
--- a/base/aws-credentials-rotator/kustomization.yaml
+++ b/base/aws-credentials-rotator/kustomization.yaml
@@ -2,12 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - rbac.yaml
-  - vault-pki.yaml
-  - vault.yaml
-configMapGenerator:
-  - name: nginx-config
-    files:
-      - resources/nginx.conf
+  - vault-aws-credentials.yaml
 images:
   - name: quay.io/utilitywarehouse/vault-toolkit
     newTag: 1.3.2-1

--- a/base/aws-credentials-rotator/rbac.yaml
+++ b/base/aws-credentials-rotator/rbac.yaml
@@ -1,0 +1,9 @@
+# Used by vault-aws-credentials-rotator to update configmaps
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: vault-configmap-patcher
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["patch"]

--- a/base/aws-credentials-rotator/vault-aws-credentials.yaml
+++ b/base/aws-credentials-rotator/vault-aws-credentials.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vault-aws-credentials
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vault-aws-credentials-rotator
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vault-aws-credentials-rotator
+spec:
+  selector:
+    matchLabels:
+      app: vault-aws-credentials-rotator
+  template:
+    metadata:
+      labels:
+        app: vault-aws-credentials-rotator
+    spec:
+      serviceAccountName: vault-aws-credentials-rotator
+      containers:
+        - name: aws-credentials-rotator
+          image: quay.io/utilitywarehouse/vault-toolkit
+          args:
+            - aws-credentials
+            - rotator
+          env:
+            - name: VAULT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: vault
+                  key: root-token
+          volumeMounts:
+            - name: tls
+              mountPath: /etc/tls
+      volumes:
+        - name: tls
+          secret:
+            secretName: vault-tls

--- a/example/vault-namespace/kustomization.yaml
+++ b/example/vault-namespace/kustomization.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 bases:
   - ../../base/vault-namespace
   # github.com/utilitywarehouse/vault-manifests//base/vault-namespace?ref=1.3.2-1
+  - ../../base/aws-credentials-rotator # exclude if you don't have an AWS secrets backend
+  # github.com/utilitywarehouse/vault-manifests//base/aws-credentials-rotator?ref=1.3.2-1
 patchesStrategicMerge:
   - vault-patch.yaml
   - vault-pki-patch.yaml

--- a/example/vault-namespace/rbac.yaml
+++ b/example/vault-namespace/rbac.yaml
@@ -15,3 +15,17 @@ subjects:
     name: vault-pki
     # Placeholder, patch with the vault namespace value
     namespace: example
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vault-configmap-patcher
+roleRef:
+  kind: Role
+  name: vault-configmap-patcher
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: vault-aws-credentials-rotator
+    # Placeholder, patch with the vault namespace value
+    namespace: example

--- a/vault-toolkit/docker-entrypoint.sh
+++ b/vault-toolkit/docker-entrypoint.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 
-exec vault-${1}.sh
+cmd="vault-${1}.sh"
+shift
+
+exec "${cmd}" "$@"

--- a/vault-toolkit/vault-aws-credentials.sh
+++ b/vault-toolkit/vault-aws-credentials.sh
@@ -1,0 +1,110 @@
+#!/bin/sh
+
+set -e
+
+VAULT_TOKEN="${VAULT_TOKEN:?"must be set"}"
+VAULT_CACERT="${VAULT_CACERT:-"/etc/tls/ca.crt"}"
+VAULT_ADDR="${VAULT_ADDR:-"https://vault:8200"}"
+CONFIG_MAP_NAME="${CONFIG_MAP_NAME:-"vault-aws-credentials"}"
+AWS_SECRET_BACKEND="${AWS_SECRET_BACKEND:="aws"}"
+
+log()
+{
+  echo "$(date -I'seconds') ${1}"
+}
+
+err()
+{
+  echo "$(date -I'seconds') ${1}" >&2
+}
+
+# init bootstraps the rotation of the IAM user credentials held by vault.
+#
+# Intended usage:
+# $ aws iam create-access-key --user-name <username>
+#   <output containing keys>
+# $ kubectl --context=<context> -n <namespace> exec -it vault-aws-credentials-rotator-<hash> -- vault-aws-credentials.sh init
+#   Access Key ID: <insert key>
+#   Secret Access Key: <insert key>
+init() {
+  # Read access key and secret key from user input
+  while [ -z "${access_key_id}" ]; do
+    read -p "Access Key ID: " access_key_id
+  done
+  while [ -z "${secret_access_key}" ]; do
+    read -sp "Secret Access Key: " secret_access_key
+    echo
+  done
+
+  # Retrieve the current config of the aws secrets backend
+  aws_config=$(curl -s --cacert "${VAULT_CACERT}" --header "X-Vault-Token: ${VAULT_TOKEN}" \
+    "${VAULT_ADDR}/v1/${AWS_SECRET_BACKEND}/config/root" \
+    | jq -r .data
+  )
+
+  # Merge the new access key and secret key into the current config
+  new_aws_config=$(jq -n \
+    --argjson data "${aws_config}" \
+    --arg a "${access_key_id}" \
+    --arg s "${secret_access_key}" \
+    '$data + {access_key: $a,secret_key: $s}'
+  )
+
+  # Update the secrets backend with the new config
+  log "updating the AWS secrets backend config"
+  curl -sSf --cacert "${VAULT_CACERT}" --header "X-Vault-Token: ${VAULT_TOKEN}" \
+    -XPOST \
+    -d "${new_aws_config}" \
+    "${VAULT_ADDR}/v1/${AWS_SECRET_BACKEND}/config/root"
+
+  # Rotate the credentials so that only vault knows the secret key
+  log "rotating the root credentials"
+  curl -sSf --cacert "${VAULT_CACERT}" --header "X-Vault-Token: ${VAULT_TOKEN}" \
+    -XPOST \
+    "${VAULT_ADDR}/v1/${AWS_SECRET_BACKEND}/config/rotate-root"
+
+  # Save the time of this rotation to a configmap
+  log "updating the date of the last rotation in the configmap"
+  kubectl patch configmap "${CONFIG_MAP_NAME}" -p '{"data":{"last_rotated_date":"'"$(date +%s)"'"}}'
+}
+
+# rotator rotates the root credentials used by the vault AWS secret backend
+rotator() {
+  CREDENTIALS_TTL="${CREDENTIALS_TTL:="86400"}"
+  while true; do
+    # get the last time the credentials were rotated
+    last_rotated_date=$(kubectl get configmap "${CONFIG_MAP_NAME}" -o jsonpath={.data.last_rotated_date})
+    if [ -z "${last_rotated_date}" ]; then
+      err "error: can't find the last rotation time in the config map ${CONFIG_MAP_NAME}"
+      sleep 30
+    else
+      # if the credentials are older than the ttl, rotate them
+      credentials_age=$(($(date +%s) - ${last_rotated_date}))
+      if [ "${credentials_age}" -ge "${CREDENTIALS_TTL}" ]; then
+        log "rotating the root credentials"
+        curl -sSf --cacert "${VAULT_CACERT}" --header "X-Vault-Token: ${VAULT_TOKEN}" \
+          -XPOST \
+          "${VAULT_ADDR}/v1/${AWS_SECRET_BACKEND}/config/rotate-root"
+
+        log "updating the date of the last rotation in the configmap"
+        kubectl patch configmap "${CONFIG_MAP_NAME}" -p '{"data":{"last_rotated_date":"'"$(date +%s)"'"}}'
+        credentials_age=0
+      fi
+      # sleep until the ttl is up
+      sleep $((CREDENTIALS_TTL-credentials_age))
+    fi
+  done
+}
+
+
+case "$1" in
+  "init")
+    init
+    ;;
+  "rotator")
+    rotator
+    ;;
+  *)
+    err "error: ${1} is not a valid argument"
+    ;;
+esac


### PR DESCRIPTION
This adds a deployment that allows for frequent and automated rotation of the IAM credentials used by the AWS secret backend.

It consists of:
1. A service that periodically calls `/v1/aws/config/rotate-root` to rotate the access key
2. A script which is ran by the user when setting up a new cluster that sets the initial credentials

These are the steps that would need to be taken as part of the bootstrapping:
```
$ aws iam create-access-key --user-name <username>
  <output containing keys>
$ kubectl --context=<context> -n <namespace> exec -it vault-aws-credentials-rotator-<hash> -- vault-aws-credentials.sh init
  Access Key ID: <insert key>
  Secret Access Key: <insert key>
```
Upsides to this approach include:
- Credentials aren't stored anywhere in git, or known outside of vault at all
- Allows us to adhere to AWS best practices around frequent access key rotation

Downsides:
- Adds some state to the vault cluster. One of the nicest things about our vault setup is that you can completely destroy the namespace and have everything back and working as intended simply by re-applying the manifests. With this change, you would have to bootstrap AWS manually again.
- Adds more complexity to the vault setup in general