### PR TITLE
export metrics with the statsd-exporter

### DIFF
--- a/base/vault-namespace/kustomization.yaml
+++ b/base/vault-namespace/kustomization.yaml
@@ -5,9 +5,9 @@ resources:
   - vault.yaml
   - vault-pki.yaml
 configMapGenerator:
-  - name: nginx-config
+  - name: statsd-mappings
     files:
-      - resources/nginx.conf
+      - resources/statsd-mappings.yaml
 images:
   - name: quay.io/utilitywarehouse/vault-toolkit
     newTag: 1.3.2-1

--- a/base/vault-namespace/resources/nginx.conf
+++ b/base/vault-namespace/resources/nginx.conf
@@ -1,9 +1,0 @@
-server {
-    listen       8080;
-    server_name  localhost;
-
-    location /__/metrics {
-        proxy_pass https://127.0.0.1:8200/v1/sys/metrics?format=prometheus;
-        proxy_ssl_verify off;
-    }
-}

--- a/base/vault-namespace/resources/statsd-mappings.yaml
+++ b/base/vault-namespace/resources/statsd-mappings.yaml
@@ -1,0 +1,24 @@
+mappings:
+  # vault.route.update.auth-kubernetes- -> vault_route{method="update",path="auth-kubernetes"}
+  - match: vault\.route\.(.*)\.(.*)-
+    match_type: regex
+    name: "vault_route"
+    labels:
+      method: "$1"
+      path: "$2"
+  # vault.rollback.attempt.sys- -> vault_rollback_attempt{path="sys"}
+  - match: vault\.rollback\.attempt\.(.*)-
+    match_type: regex
+    name: "vault_rollback_attempt"
+    labels:
+      path: "$1"
+  # vault.barrier.delete -> vault_barrier{method="delete"}
+  - match: vault.barrier.*
+    name: "vault_barrier"
+    labels:
+      method: "$1"
+  # vault.raft.storage.get -> vault_raft_storage{method="get"}
+  - match: vault.raft.storage.*
+    name: "vault_raft_storage"
+    labels:
+      method: "$1"

--- a/base/vault-namespace/vault.yaml
+++ b/base/vault-namespace/vault.yaml
@@ -57,8 +57,8 @@ spec:
         app: vault
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/path: /__/metrics
-        prometheus.io/port: "8080"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9102"
     spec:
       serviceAccountName: vault
       shareProcessNamespace: true
@@ -98,9 +98,6 @@ spec:
                   cluster_address = "0.0.0.0:8201"
                   tls_key_file    = "/etc/tls/tls.key"
                   tls_cert_file   = "/etc/tls/tls.crt"
-                  telemetry {
-                    unauthenticated_metrics_access = true
-                  }
                 }
 
                 storage "raft" {
@@ -109,8 +106,8 @@ spec:
                 }
 
                 telemetry {
-                  prometheus_retention_time = "90s",
                   disable_hostname = true
+                  statsd_address = "localhost:9125"
                 }
 
                 api_addr      = "https://$(POD_NAME).vault.$(POD_NAMESPACE):8200"
@@ -185,13 +182,17 @@ spec:
             runAsUser: 1000
             runAsGroup: 100
             allowPrivilegeEscalation: false
-        - name: metrics
-          image: nginx:alpine
+        - name: statsd-exporter
+          image: prom/statsd-exporter:v0.15.0
+          args:
+            - --statsd.mapping-config=/statsd-mappings.yaml
           ports:
-            - containerPort: 80
+            - containerPort: 9125
+            - containerPort: 9102
           volumeMounts:
-            - name: nginx-config
-              mountPath: /etc/nginx/conf.d
+            - name: statsd-mappings
+              mountPath: /statsd-mappings.yaml
+              subPath: statsd-mappings.yaml
         - name: reloader
           image: alpine
           securityContext:
@@ -220,9 +221,9 @@ spec:
             defaultMode: 0400
         - name: vault-config
           emptyDir: {}
-        - name: nginx-config
+        - name: statsd-mappings
           configMap:
-            name: nginx-config
+            name: statsd-mappings
   volumeClaimTemplates:
     - metadata:
         name: storage


### PR DESCRIPTION
The vault prometheus metrics are less than ideal for a couple of reasons:
* They're event based, and metrics are only exported when a particular event happens and persisted for as long as `prometheus_retention_time`. Additionally, counters seem to be reset every time a metric reappears, meaning you're essentially getting the rate as a gauge. We could increase the retention time to mitigate this a bit (it's currently set to `90s`).
* The conversion from statsd format to prometheus format is done naively,
resulting in information being placed into metrics names that should probably go
into labels. For instance `vault_rollback_attempt_aws_` and `vault_rollback_attempt_cubbyhole_` which could be `vault_rollback_attempt{path="aws"}` and `vault_rollback_attempt{path="cubbyhole"}`.

The statsd-exporter performs the exact same conversion from statsd to prometheus but metrics received from vault are persisted for the life of the exporter, meaning that counters are incremented as expected and series will generally persist for the lifetime of the pod. It also allows you to map parts of the statsd metric names to labels, resulting in more useful metrics.

I've mapped some metrics that stood out to me, but I'd like to follow up by reviewing them all more thoroughly.