### PR TITLE
add vault-exporter

### DIFF
--- a/base/vault-namespace/vault.yaml
+++ b/base/vault-namespace/vault.yaml
@@ -182,6 +182,16 @@ spec:
             runAsUser: 1000
             runAsGroup: 100
             allowPrivilegeEscalation: false
+        - name: vault-exporter
+          image: quay.io/giantswarm/vault-exporter:1.0.0
+          env:
+            - name: VAULT_CACERT
+              value: "/etc/tls/ca.crt"
+          ports:
+            - containerPort: 9410
+          volumeMounts:
+            - name: tls
+              mountPath: /etc/tls
         - name: statsd-exporter
           image: prom/statsd-exporter:v0.15.0
           args:

--- a/base/vault-namespace/vault.yaml
+++ b/base/vault-namespace/vault.yaml
@@ -41,6 +41,40 @@ spec:
     - port: 8201
       name: members-internal-api
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vault-statsd-exporter
+  labels:
+    app: vault
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "9102"
+spec:
+  selector:
+    app: vault
+  ports:
+    - port: 9102
+      name: statsd-exporter
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vault-exporter
+  labels:
+    app: vault
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "9410"
+spec:
+  selector:
+    app: vault
+  ports:
+    - port: 9410
+      name: vault-exporter
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -55,10 +89,6 @@ spec:
     metadata:
       labels:
         app: vault
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/path: /metrics
-        prometheus.io/port: "9102"
     spec:
       serviceAccountName: vault
       shareProcessNamespace: true


### PR DESCRIPTION
https://github.com/giantswarm/vault-exporter

This exports some metrics that are more useful for divining and alerting upon the state of replicas in the cluster, allowing us to identify when vault is sealed, uninitialized or leaderless.

Unfortunately it seems that the source repository for this exporter was deleted, leaving behind a lot of forks and mirrors with no clear favourite for succession. I've gone with giantswarm's fork as they're a pretty well known and reputable company as far as I can tell and they seem to be actively maintaining it. We could fork as well if we're concerned about using them.