### PR TITLE
Remove liveness probe

### DIFF
--- a/base/vault-namespace/vault.yaml
+++ b/base/vault-namespace/vault.yaml
@@ -175,14 +175,6 @@ spec:
               mountPath: /etc/tls
         - name: vault
           image: vault:1.4.1
-          livenessProbe:
-            # Alive if Vault is uninitialized or unsealed and active/standby
-            httpGet:
-              path: /v1/sys/health?standbyok=true&uninitcode=204
-              port: 8200
-              scheme: HTTPS
-            initialDelaySeconds: 30
-            periodSeconds: 10
           readinessProbe:
             # Ready if Vault is initialized, unsealed and active/standby
             httpGet:


### PR DESCRIPTION
Killing an unsealed vault isn't very useful. It's actually counter-productive as the restarted vault container won't get unsealed and will just bounce up and down making it difficult to triage.

Better to let it go unready and then we can investigate that.