### PR TITLE
Use bash for vault-toolkit scripts

### DIFF
--- a/vault-toolkit/Dockerfile
+++ b/vault-toolkit/Dockerfile
@@ -5,7 +5,7 @@ ENV KUBECTL_VERSION="1.17.3"
 
 COPY *.sh /usr/local/bin/
 
-RUN apk --no-cache add curl jq &&\
+RUN apk --no-cache add curl jq bash &&\
     wget -O /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl &&\
     chmod +x /usr/local/bin/kubectl &&\
     wget -O /usr/local/bin/cfssl https://github.com/cloudflare/cfssl/releases/download/v${CFSSL_VERSION}/cfssl_${CFSSL_VERSION}_linux_amd64 &&\

--- a/vault-toolkit/docker-entrypoint.sh
+++ b/vault-toolkit/docker-entrypoint.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/bash
 
-exec vault-${1}.sh
+exec "vault-${1}.sh"

--- a/vault-toolkit/vault-initializer.sh
+++ b/vault-toolkit/vault-initializer.sh
@@ -25,8 +25,7 @@ fi
 # If there's no current leader and this is the first replica then initialize
 # the cluster, otherwise join the current leader
 unseal_key=""
-leader_addr=$(curl -Ss -f --cacert "${VAULT_CACERT}" "${vault_addr}/v1/sys/leader" | jq -r '.leader_address')
-if [ -z "${leader_addr}" ]; then
+if [ -z "$(curl -Ss -f --cacert "${VAULT_CACERT}" "${vault_addr}/v1/sys/leader" | jq -r '.leader_address')" ]; then
   if [ "${HOSTNAME: -1}" = "0" ]; then
     # Initialize vault and update secret
     init=$(curl -Ss -f --cacert "${VAULT_CACERT}" "${local_addr}/v1/sys/init" \
@@ -41,6 +40,7 @@ if [ -z "${leader_addr}" ]; then
   fi
 else
   # join the leader
+  leader_addr=$(curl -Ss -f --cacert "${VAULT_CACERT}" "${vault_addr}/v1/sys/leader" | jq -r '.leader_address')
   leader_ca_cert=$(awk 'NF {printf "%s\\n",$0;}' "${VAULT_CACERT}")
   curl -Ss -f --cacert "${VAULT_CACERT}" "${local_addr}/v1/sys/storage/raft/join" -XPUT \
     -d '{

--- a/vault-toolkit/vault-initializer.sh
+++ b/vault-toolkit/vault-initializer.sh
@@ -1,11 +1,13 @@
-#!/bin/sh
+#!/bin/bash
 
 # This script initializes the local vault.
 
-set -e
+set -o nounset
+set -o errexit
+set -o pipefail
 
 # Validations and defaults
-: ${VAULT_CACERT:?"Need to set VAULT_CACERT"}
+: "${VAULT_CACERT:?Need to set VAULT_CACERT}"
 local_addr="${VAULT_LOCAL_ADDR:-"https://127.0.0.1:8200"}"
 vault_addr="${VAULT_ADDR:-"https://vault:8200"}"
 

--- a/vault-toolkit/vault-initializer.sh
+++ b/vault-toolkit/vault-initializer.sh
@@ -24,6 +24,7 @@ fi
 
 # If there's no current leader and this is the first replica then initialize
 # the cluster, otherwise join the current leader
+unseal_key=""
 leader_addr=$(curl -Ss -f --cacert "${VAULT_CACERT}" "${vault_addr}/v1/sys/leader" | jq -r '.leader_address')
 if [ -z "${leader_addr}" ]; then
   if [ "${HOSTNAME: -1}" = "0" ]; then

--- a/vault-toolkit/vault-unsealer.sh
+++ b/vault-toolkit/vault-unsealer.sh
@@ -7,6 +7,7 @@ set -o errexit
 set -o pipefail
 
 vault_addr="${VAULT_ADDR:-"https://127.0.0.1:8200"}";
+UNSEAL_KEY="${UNSEAL_KEY:-}"
 
 # Sleep if no unseal key provided
 if [ -z "${UNSEAL_KEY}" ]; then
@@ -15,6 +16,7 @@ if [ -z "${UNSEAL_KEY}" ]; then
 fi
 
 # Wait for vault api and sleep if not initialized
+initialized=""
 until [ "${initialized}" == "true" ] || [ "${initialized}" == "false" ]; do
   initialized=$(curl -Ss -f --cacert "${VAULT_CACERT}" "${vault_addr}/v1/sys/init" | jq '.initialized');
   echo 'leader not ready, sleeping for 3 seconds';

--- a/vault-toolkit/vault-unsealer.sh
+++ b/vault-toolkit/vault-unsealer.sh
@@ -1,8 +1,10 @@
-#!/bin/sh
+#!/bin/bash
 
 # This script unseals the local vault instance with the ${UNSEAL_KEY}
 
-set -e
+set -o nounset
+set -o errexit
+set -o pipefail
 
 vault_addr="${VAULT_ADDR:-"https://127.0.0.1:8200"}";
 
@@ -13,7 +15,7 @@ if [ -z "${UNSEAL_KEY}" ]; then
 fi
 
 # Wait for vault api and sleep if not initialized
-until [ "${initialized}" = "true" -o "${initialized}" = "false" ]; do
+until [ "${initialized}" == "true" ] || [ "${initialized}" == "false" ]; do
   initialized=$(curl -Ss -f --cacert "${VAULT_CACERT}" "${vault_addr}/v1/sys/init" | jq '.initialized');
   echo 'leader not ready, sleeping for 3 seconds';
   sleep 3;


### PR DESCRIPTION
This is primarily to allow the use of `pipefail` in order to properly handle `curl` failures.