### PR TITLE
vault 1.5.0

### DIFF
--- a/base/vault-namespace/rbac.yaml
+++ b/base/vault-namespace/rbac.yaml
@@ -1,9 +1,24 @@
-# Used by vault initializer and vault-pki to update secrets
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: vault-secret-applier
+  name: vault
 rules:
+  # Allows vault pods to label themselves with their current status:
+  #   - https://www.vaultproject.io/docs/configuration/service-registration/kubernetes
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "update", "patch"]
+  # Used by vault initializer to update secrets
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: vault-pki
+rules:
+  # Used by vault-pki-manager to update secrets with certificates
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "create", "update", "patch"]

--- a/base/vault-namespace/vault.yaml
+++ b/base/vault-namespace/vault.yaml
@@ -140,6 +140,11 @@ spec:
                   statsd_address = "localhost:9125"
                 }
 
+                service_registration "kubernetes" {
+                  namespace = "$(POD_NAMESPACE)"
+                  pod_name  = "$(POD_NAME)"
+                }
+
                 api_addr      = "https://$(POD_NAME).vault.$(POD_NAMESPACE):8200"
                 cluster_addr  = "https://$(POD_NAME).vault-cluster.$(POD_NAMESPACE):8201"
                 disable_mlock = true
@@ -174,7 +179,7 @@ spec:
             - name: tls
               mountPath: /etc/tls
         - name: vault
-          image: vault:1.4.3
+          image: vault:1.5.0
           readinessProbe:
             # Ready if Vault is initialized, unsealed and active/standby
             httpGet:

--- a/example/vault-namespace/rbac.yaml
+++ b/example/vault-namespace/rbac.yaml
@@ -1,16 +1,26 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: vault-secret-applier
+  name: vault
 roleRef:
   kind: Role
-  name: vault-secret-applier
+  name: vault
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
     name: vault
     # Placeholder, patch with the vault namespace value
     namespace: example
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vault-pki
+roleRef:
+  kind: Role
+  name: vault
+  apiGroup: rbac.authorization.k8s.io
+subjects:
   - kind: ServiceAccount
     name: vault-pki
     # Placeholder, patch with the vault namespace value


### PR DESCRIPTION
- https://github.com/hashicorp/vault/blob/master/CHANGELOG.md#150

Includes a fix for kubernetes service registration, which labels the pod with its vault state. This is pretty handy for figuring out the state of the cluster at a glance.