### PR TITLE
Add ns list permissions to vault-pki ClusterRole

### DIFF
--- a/base/cluster-wide/rbac.yaml
+++ b/base/cluster-wide/rbac.yaml
@@ -50,3 +50,9 @@ rules:
       - "get"
       - "patch"
       - "update"
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - "list"


### PR DESCRIPTION
The vault-pki-manager needs permission to list namespaces so it can copy configmaps into them. This hasn't been an issue up until now because we aggregate all authenticated accounts to the `view` ClusterRole. Nevertheless, this base shouldn't rely on that being the case.