### PR TITLE
Change max age on vault.raft.leader.lastContact summary

### DIFF
--- a/base/vault-namespace/resources/statsd-mappings.yaml
+++ b/base/vault-namespace/resources/statsd-mappings.yaml
@@ -32,6 +32,7 @@ mappings:
   # Changing the window to 30sec will more accurately show these spikes.
   - match: vault.raft.leader.lastContact
     name: "vault_raft_leader_lastContact"
+    observer_type: summary
     summary_options:
       max_summary_age: 30s
       # With only one age bucket, you will

--- a/base/vault-namespace/resources/statsd-mappings.yaml
+++ b/base/vault-namespace/resources/statsd-mappings.yaml
@@ -34,3 +34,7 @@ mappings:
     name: "vault_raft_leader_lastContact"
     summary_options:
       max_summary_age: 30s
+      # With only one age bucket, you will
+      # effectively see a complete reset of the summary each time MaxAge has
+      # passed.
+      summary_age_buckets: 1

--- a/base/vault-namespace/resources/statsd-mappings.yaml
+++ b/base/vault-namespace/resources/statsd-mappings.yaml
@@ -26,3 +26,10 @@ mappings:
     timer_type: histogram
     labels:
       method: "$1"
+  # vault_raft_leader_lastContact is a summary
+  # (https://prometheus.io/docs/concepts/metric_types/#summary) and has a default
+  # sliding window of 10m. This is not useful when we have short, sharp spikes.
+  # Changing the window to 30sec will more accurately show these spikes.
+  - match: vault.raft.leader.lastContact
+    summary_options:
+      max_summary_age: 30s

--- a/base/vault-namespace/resources/statsd-mappings.yaml
+++ b/base/vault-namespace/resources/statsd-mappings.yaml
@@ -31,5 +31,6 @@ mappings:
   # sliding window of 10m. This is not useful when we have short, sharp spikes.
   # Changing the window to 30sec will more accurately show these spikes.
   - match: vault.raft.leader.lastContact
+    name: "vault_raft_leader_lastContact"
     summary_options:
       max_summary_age: 30s


### PR DESCRIPTION
Set to 30sec (same as sample size) to avoid having a long "tail" on spikes.
