### PR TITLE
Improve distribution of CA cert to namespaces

### DIFF
--- a/base/cluster-wide/rbac.yaml
+++ b/base/cluster-wide/rbac.yaml
@@ -55,4 +55,6 @@ rules:
     resources:
       - namespaces
     verbs:
+      - "get"
       - "list"
+      - "watch"

--- a/vault-toolkit/vault-pki-manager.sh
+++ b/vault-toolkit/vault-pki-manager.sh
@@ -12,50 +12,93 @@ set -o pipefail
 secret_name="${VAULT_SECRET_NAME:-"vault-tls"}"
 vault_name="${VAULT_NAME:-"vault"}"
 replicas="${VAULT_REPLICAS:-"3"}"
+vault_namespaces="${VAULT_CLIENT_NAMESPACES:-""}"
+ca_crt="${VAULT_CACERT:-"/etc/tls/ca.crt"}"
 
 output_dir="./pki"
 rm -rf "${output_dir}"
 mkdir "${output_dir}"
 
-# update_client_namespaces copies ca.crt into a configmap in every namespace in
-# the cluster. The list of namespaces can be constrained by setting a
-# space-delimited list in VAULT_CLIENT_NAMESPACES.
-#
-# This function is ran when the certificate is rotated and subsequently every 25
-# minutes to ensure new namespaces receive the certificate after a reasonable
-# amount of time.
-update_client_namespaces() {
-    vault_namespaces="${VAULT_CLIENT_NAMESPACES:-""}"
-    ca_crt="${1}"
+# update_client_namespace copies the CA cert to a configmap in the provided namespace
+update_client_namespace() {
+  ns=$1
+  cert=$2
 
-    if [[ -z "${vault_namespaces}" ]]; then
-        vault_namespaces=$(kubectl get ns -o name \
-          | sed 's|namespace/||g' \
-          | xargs
-        )
-    fi
+  echo "Updating configmap in ${ns}"
+  kubectl -n "${ns}" create configmap "${secret_name}" \
+    --from-file "${cert}" 2>/dev/null \
+    || kubectl -n "${ns}" create configmap "${secret_name}" \
+        --from-file "${cert}" \
+        --dry-run=client -o yaml | kubectl -n "${ns}" replace -f -
+}
+
+# update_client_namespaces copies the CA cert into a configmap in every namespace
+# in the cluster. The list of namespaces can be constrained by setting a
+# space-delimited list in VAULT_CLIENT_NAMESPACES.
+update_client_namespaces() {
+    cert=$1
 
     echo "Updating CA in client namespaces"
-    for n in $vault_namespaces; do
-        echo "Updating configmap in ${n}"
-        kubectl -n "${n}" create configmap "${secret_name}" \
-            --from-file "${ca_crt}" 2>/dev/null \
-            || kubectl -n "${n}" create configmap "${secret_name}" \
-                --from-file "${ca_crt}" \
-                --dry-run=client -o yaml | kubectl -n "${n}" replace -f -
-    done
+    while read -r line; do
+      ns="${line#*/}"
+      if is_client_namespace "${ns}"; then
+        update_client_namespace "${ns}" "${cert}"
+      fi
+    done < <(kubectl get ns -o name)
 }
+
+# update_new_client_namespaces watches for new namespaces and copies the ca cert into them as they're
+# added
+update_new_client_namespaces() {
+  cert=$1
+
+  echo "Watching for new namespaces..."
+  while true; do
+    while read -r line; do
+      event=$(awk '{print $1}' <<<"${line}")
+      ns=$(awk '{print $2}' <<<"${line}")
+
+      if [[ "${event}" == "ADDED" ]] && is_client_namespace "${ns}" && [[ -f "${cert}" ]]; then
+        echo "Event received: ${event} ${ns}"
+        update_client_namespace "${ns}" "${cert}"
+      fi
+    done < <(kubectl get ns --watch-only --output-watch-events --no-headers)
+
+    # Add a brief delay before starting the watch again to avoid hammering the
+    # apiserver in the case of issues
+    sleep 2
+  done
+}
+
+# is_client_namespace returns true if the namespace is in the list of client
+# namespaces (or the client namespaces list is empty, which implicitly means
+# all)
+is_client_namespace() {
+  ns=$1
+
+  [[ -z $vault_namespaces ]] || [[ $vault_namespaces =~ (^|[[:space:]])"$ns"($|[[:space:]]) ]]
+}
+
+# Cleanup child processes
+trap "kill 0" EXIT
+
+# Ensure the certificate is copied into all client namespaces, if it exists
+if [[ -f "${ca_crt}" ]]; then
+  update_client_namespaces "${ca_crt}"
+fi
+
+# In a background process, ensure new namespaces receive the certificate
+update_new_client_namespaces "${ca_crt}" &
 
 # Main loop
 while true; do
     # Sleep if certificate is not expiring soon
-    if [[ -f /etc/tls/ca.crt ]]; then
+    if [[ -f "${ca_crt}" ]]; then
         now_seconds=$(date +%s)
-        cert_expiration=$(cfssl certinfo -cert /etc/tls/ca.crt | jq -r '.not_after' | sed -e 's/T/ /g' -e 's/Z$//g')
+        cert_expiration=$(cfssl certinfo -cert "${ca_crt}" | jq -r '.not_after' | sed -e 's/T/ /g' -e 's/Z$//g')
         expiration_seconds=$(date -d "${cert_expiration}" +%s)
         validity=$((expiration_seconds - now_seconds))
         if [[ ${validity} -gt 7200 ]]; then # 2h
-            update_client_namespaces "/etc/tls/ca.crt"
             sleep 1500 # 25 min
             continue
         fi


### PR DESCRIPTION
Copy the CA certificate to new namespaces as they are created, rather than copying to every namespace every 25 minutes.

This should reduce unnecessary calls to the apiserver as well as ensuring that new namespaces receive the cert immediately, rather than at some point in the next 25 mins.