### PR TITLE
Add anti-affinity based on hostname as well as topology

### DIFF
--- a/base/vault-namespace/vault.yaml
+++ b/base/vault-namespace/vault.yaml
@@ -112,6 +112,15 @@ spec:
                       operator: In
                       values:
                         - vault
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - vault
                 topologyKey: topology.kubernetes.io/zone
               weight: 100
       initContainers:


### PR DESCRIPTION
Merit doesn't currently have any concept of 'topology', so pods can be scheduled onto the same nodes.