### PR TITLE
Update kubernetes download link

### DIFF
--- a/vault-toolkit/Dockerfile
+++ b/vault-toolkit/Dockerfile
@@ -6,7 +6,7 @@ ENV KUBECTL_VERSION="1.28.4"
 COPY *.sh /usr/local/bin/
 
 RUN apk --no-cache add curl jq bash \
-      && wget -O /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
+      && wget -O /usr/local/bin/kubectl https://dl.k8s.io/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
       && chmod +x /usr/local/bin/kubectl \
       && wget -O /usr/local/bin/cfssl https://github.com/cloudflare/cfssl/releases/download/v${CFSSL_VERSION}/cfssl_${CFSSL_VERSION}_linux_amd64 \
       && chmod +x /usr/local/bin/cfssl \


### PR DESCRIPTION
The gcp bucket doesn't seem to get updated anymore. Switching to the new
link recommended in https://kubernetes.io/releases/download/
